### PR TITLE
fix(all/jellyfin): Fix credentials when changing server

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -538,7 +538,7 @@ class Jellyfin(private val suffix: String) : ConfigurableAnimeSource, AnimeHttpS
             validationMessage = "The URL is invalid, malformed, or ends with a slash",
             key = HOSTURL_KEY,
             restartRequired = true,
-        ) { preferences.clearApiKey() }
+        ) { preferences.clearCredentials() }
 
         screen.addEditTextPreference(
             title = "Username",
@@ -546,7 +546,7 @@ class Jellyfin(private val suffix: String) : ConfigurableAnimeSource, AnimeHttpS
             summary = username.ifBlank { "The user account name" },
             key = USERNAME_KEY,
             restartRequired = true,
-        ) { preferences.clearApiKey() }
+        ) { preferences.clearCredentials() }
 
         screen.addEditTextPreference(
             title = "Password",
@@ -555,7 +555,7 @@ class Jellyfin(private val suffix: String) : ConfigurableAnimeSource, AnimeHttpS
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
             key = PASSWORD_KEY,
             restartRequired = true,
-        ) { preferences.clearApiKey() }
+        ) { preferences.clearCredentials() }
 
         ListPreference(screen.context).apply {
             key = MEDIALIB_KEY

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Utils.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Utils.kt
@@ -21,8 +21,11 @@ val SharedPreferences.password
 val SharedPreferences.apiKey
     get() = getString(Jellyfin.APIKEY_KEY, "")!!
 
-fun SharedPreferences.clearApiKey() {
-    edit().remove(Jellyfin.APIKEY_KEY).apply()
+fun SharedPreferences.clearCredentials() {
+    edit()
+        .remove(Jellyfin.APIKEY_KEY)
+        .remove(Jellyfin.USERID_KEY)
+        .apply()
 }
 
 fun Long.formatBytes(): String = when {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have tested the modifications by compiling and running the extension through Android Studio