### PR TITLE
fix: allow codec field to be optional

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 31
+    extVersionCode = 32
     extNames = ["Jellyfin (1)", "Jellyfin (2)", "Jellyfin (3)"]
 }
 

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -507,18 +507,8 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                 }
 
                 "Subtitle" -> {
-                    if (media.supportsExternalStream) {
+                    if (media.supportsExternalStream && media.codec != null) {
                         val subtitleUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                            addPathSegment("Videos")
-                            addPathSegment(itemId)
-                            addPathSegment(mediaSource.id!!)
-                            addPathSegment("Subtitles")
-                            addPathSegment(media.index.toString())
-                            addPathSegment("0")
-                            if (media.codec != null) {
-                                addPathSegment("Stream.${media.codec}")
-                        if (media.supportsExternalStream && media.codec != null) {
-                            val subtitleUrl = baseUrl.toHttpUrl().newBuilder().apply {
                             addPathSegment("Videos")
                             addPathSegment(itemId)
                             addPathSegment(mediaSource.id!!)

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -517,7 +517,15 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                             addPathSegment("0")
                             if (media.codec != null) {
                                 addPathSegment("Stream.${media.codec}")
-                            }
+                        if (media.supportsExternalStream && media.codec != null) {
+                            val subtitleUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                            addPathSegment("Videos")
+                            addPathSegment(itemId)
+                            addPathSegment(mediaSource.id!!)
+                            addPathSegment("Subtitles")
+                            addPathSegment(media.index.toString())
+                            addPathSegment("0")
+                            addPathSegment("Stream.${media.codec}")
                         }.build().toString()
 
                         if (media.isExternal) {

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -515,7 +515,9 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                             addPathSegment("Subtitles")
                             addPathSegment(media.index.toString())
                             addPathSegment("0")
-                            addPathSegment("Stream.${media.codec}")
+                            if (media.codec != null) {
+                                addPathSegment("Stream.${media.codec}")
+                            }
                         }.build().toString()
 
                         if (media.isExternal) {

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/dto/ItemDto.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/dto/ItemDto.kt
@@ -262,7 +262,7 @@ data class MediaDto(
 ) {
     @Serializable
     data class MediaStreamDto(
-        val codec: String,
+        val codec: String? = null,
         val index: Int,
         val type: String,
         val supportsExternalStream: Boolean,


### PR DESCRIPTION
Hi, thank you for the works. The extension is working great, but I encounter missing codec field error in some of my library. I tried to check said library using ffmpeg, turn out it did miss some audio codec. Though the movie and its audio is working fine. 

So, this change is just to make codec filed to be optional. Take a note that I don't fully understand how Jellyfin nor video component work. So, I don't know whether this change will break other code or not. Please forgive my English, it's not my first language. Thanks!

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
